### PR TITLE
Move React dependencies in to `client/package.json`

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -7,8 +7,11 @@
     "axios": "^0.25.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-icons": "^4.3.1",
     "react-router-dom": "^6.2.1",
     "react-scripts": "^5.0.0",
+    "react-scroll": "^1.8.4",
+    "styled-components": "^5.3.3",
     "web-vitals": "^2.1.3"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -18,10 +18,7 @@
     "body-parser": "^1.19.0",
     "dotenv": "^14.2.0",
     "express": "^4.17.1",
-    "mongoose": "^6.1.7",
-    "react-icons": "^4.3.1",
-    "react-scroll": "^1.8.4",
-    "styled-components": "^5.3.3"
+    "mongoose": "^6.1.7"
   },
   "devDependencies": {
     "concurrently": "^7.0.0",


### PR DESCRIPTION
Fixes "invalid hook calls" error.

Make sure stop the client and run `npm run dev-install` to correct the package lock files before starting the client again.